### PR TITLE
Fix employee search loop and add manual validation

### DIFF
--- a/PROYECTO-FINAL/Controlador/arregloEmpleados.py
+++ b/PROYECTO-FINAL/Controlador/arregloEmpleados.py
@@ -20,10 +20,10 @@ class ArregloEmpleados():
         return len(self.dataEmpleado)
 
     def buscarEmpleado(self, dni): # Busca los Empleados por dni
-        for i in range (self.tamañoArregloEmpleado()):
+        for i in range(self.tamañoArregloEmpleado()):
             if dni == self.dataEmpleado[i].getDniEmpleado():
-                return i # devuelve la posicion del elemento encontrado
-            return -1  # signfica que no encontro ningun dato
+                return i  # devuelve la posicion del elemento encontrado
+        return -1  # significa que no encontro ningun dato
 
     def eliminarEmpleado(self, pos): # Elimina los Empleados
         del(self.dataEmpleado[pos])
@@ -33,6 +33,17 @@ class ArregloEmpleados():
 
     def retornarDatos(self): # retorna los datos de los Empleados
         return self.dataEmpleado
+
+
+if __name__ == "__main__":
+    # Prueba manual: insertar dos empleados y buscar el segundo
+    arreglo = ArregloEmpleados()
+    emp1 = empleado("111", "Juan", "Perez", "Lopez", "Calle 1", "999999")
+    emp2 = empleado("222", "Ana", "Gomez", "Diaz", "Calle 2", "888888")
+    arreglo.adicionaEmpleado(emp1)
+    arreglo.adicionaEmpleado(emp2)
+    resultado = arreglo.buscarEmpleado("222")
+    print(f"Posición del empleado con DNI 222: {resultado}")
 
     
             


### PR DESCRIPTION
## Summary
- ensure `buscarEmpleado` searches entire list before failing
- add manual test that inserts two employees and verifies searching for the second

## Testing
- `python -m Controlador.arregloEmpleados`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d8250ebec832e85807430bef30f66