### PR TITLE
Fix focus handling in client window validation

### DIFF
--- a/PROYECTO-FINAL/Vista/ventanaClientes.py
+++ b/PROYECTO-FINAL/Vista/ventanaClientes.py
@@ -67,22 +67,22 @@ class VentanaClientes(QtWidgets.QMainWindow):
 
     def valida(self):
         if self.txtDni.text() =="":
-            self.txtDni.setfocus()
+            self.txtDni.setFocus()
             return "DNI del cliente...!!!"
         elif self.txtNombres.text()=="":
-            self.txtNombres.setfocus()
+            self.txtNombres.setFocus()
             return "Nombre del cliente...!!!"
         elif self.txtApellidoPaterno.text()=="":
-            self.txtApellidoPaterno.setfocus()
+            self.txtApellidoPaterno.setFocus()
             return "Apellido Paterno del cliente...!!!"
         elif self.txtApellidoMaterno.text()=="":
-            self.txtApellidoMaterno.setfocus()
+            self.txtApellidoMaterno.setFocus()
             return "Apellido Mateno del cliente...!!!"
         elif self.txtDireccion.text()=="":
-            self.txtDireccion.setfocus()
+            self.txtDireccion.setFocus()
             return "Direccion del cliente...!!!"
         elif self.txtTelefono.text()=="":
-            self.txtTelefono.setfocus()
+            self.txtTelefono.setFocus()
             return "Telefono del cliente...!!!"
         else:
             return ""


### PR DESCRIPTION
## Summary
- Replace deprecated `setfocus()` calls with `setFocus()` in the client window validation

## Testing
- `QT_QPA_PLATFORM=offscreen python - <<'PY'
from PyQt5 import QtWidgets
import importlib.util, sys, os
os.chdir('PROYECTO-FINAL')
sys.path.append('.')

spec = importlib.util.spec_from_file_location("ventanaClientes", "Vista/ventanaClientes.py")
vc_module = importlib.util.module_from_spec(spec)
spec.loader.exec_module(vc_module)
VentanaClientes = vc_module.VentanaClientes

app = QtWidgets.QApplication([])
w = VentanaClientes()
w.show()
app.processEvents()

# Scenario 1: all fields empty
msg1 = w.valida()
app.processEvents()
print('Escenario1 mensaje:', msg1)
print('Escenario1 foco Dni:', w.txtDni.hasFocus())
print('Escenario1 foco Nombres:', w.txtNombres.hasFocus())

# Scenario 2: set Dni, but Nombres empty
w.txtDni.setText('123')
msg2 = w.valida()
app.processEvents()
print('Escenario2 mensaje:', msg2)
print('Escenario2 foco Dni:', w.txtDni.hasFocus())
print('Escenario2 foco Nombres:', w.txtNombres.hasFocus())
PY`

------
https://chatgpt.com/codex/tasks/task_e_689d82519284832ea9d1197d878a374b